### PR TITLE
removed squashed jump protection when scout margin formula is used, saving of ratio_dict values to DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Feel free to modify that file to test and compare different settings and time pe
 
 ## Database warmup
 
-You can warmup your database with coins wich you might want to add later to your supported coin list. 
+You can warmup your database with coins wich you might want to add later to your supported coin list.
 This should prevent uncontrolled jumps when you add a new coin to your supported coin list.
 
 After the execution you should wait one or two trades of the bot before adding any new coin to your list.
@@ -150,6 +150,28 @@ If not provided the script will warmup all coins available for the bridge.
 
 ```shell
 python3 database_warmup.py -c 'ADA BTC ETH LTC'
+```
+
+## Showing the current ratio changes
+
+This fork is along with scout history also saving the current changes in coin ratios.
+Those ratios are used by the bot to determine whether a jump to an another coin will
+yield more amount of the coin compared to a previous holding of that coin.
+If you are using the [BTB-manager-telegram](https://github.com/lorcalhost/BTB-manager-telegram)
+(see below), then shown ratios (`Current ratios` and `Next coin` buttons) are
+actually computed again, and mainly, not so accurately (fixed fee value).
+
+You can use the `show_ratio_changes.py` script to show the latest values of ratio changes:
+
+```shell
+python3 show_ratio_changes.py
+```
+
+You can add it to custom scripts (`config/custom_scripts.json`) in
+[BTB-manager-telegram](https://github.com/lorcalhost/BTB-manager-telegram):
+
+```json
+"Show ratio changes": "python3 ../binance-trade-bot/show_ratio_changes.py"
 ```
 
 ## Developing

--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -237,7 +237,7 @@ class AutoTrader(ABC):
             to_fee = self.manager.get_fee(to_coin.symbol, self.config.BRIDGE.symbol, False)
             transaction_fee = from_fee + to_fee - from_fee * to_fee
 
-            if self.config.USE_MARGIN == "yes":
+            if self.config.USE_MARGIN:
                 ratio_dict[(coin.idx, to_coin.idx)] = (
                     (1 - transaction_fee) * coin_opt_coin_ratio / ratio - 1 - self.config.SCOUT_MARGIN / 100
                 )

--- a/binance_trade_bot/auto_trader.py
+++ b/binance_trade_bot/auto_trader.py
@@ -251,12 +251,23 @@ class AutoTrader(ABC):
 
         return ratio_dict, price_amounts
 
-    @postpone_heavy_calls
     def _jump_to_best_coin(
+        self, coin: CoinStub, coin_sell_price: float, quote_amount: float, coin_amount: float
+    ):
+        if self.config.USE_MARGIN:
+            self._jump_to_best_coin_scout_margin(coin, coin_sell_price, quote_amount, coin_amount)
+        else:
+            self._jump_to_best_coin_scout_multiplier(coin, coin_sell_price, quote_amount, coin_amount)
+
+    @postpone_heavy_calls
+    def _jump_to_best_coin_scout_multiplier(
         self, coin: CoinStub, coin_sell_price: float, quote_amount: float, coin_amount: float
     ):  # pylint: disable=too-many-locals
         """
-        Given a coin, search for a coin to jump to
+        Given a coin, search for a coin to jump to.
+        This is the original implementation from idkravitz which prevents fast
+        subsequent jumps between the same coins (squashed jumps).
+        It might happen when scout multiplier formula is used.
         """
         can_walk_deeper = True
         jump_chain = [coin.symbol]
@@ -322,6 +333,37 @@ class AutoTrader(ABC):
             else:
                 self.update_trade_threshold(coin, None, coin_sell_price, 0, quote_amount)
                 self.logger.info(f"Eliminated jump loop from {coin.symbol} to {coin.symbol}")
+
+    @postpone_heavy_calls
+    def _jump_to_best_coin_scout_margin(
+        self, coin: CoinStub, coin_sell_price: float, quote_amount: float, coin_amount: float
+    ):  # pylint: disable=too-many-locals
+        """
+        Given a coin, search for a coin to jump to.
+        This implementation is almost similar to the original version from edeng23.
+        """
+        ratio_dict, prices = self._get_ratios(
+            coin, coin_sell_price, quote_amount, enable_scout_log=True
+        )
+        ratio_dict = {k: v for k, v in ratio_dict.items() if v > 0}
+
+        if ratio_dict:
+            best_pair = max(ratio_dict, key=ratio_dict.get)
+            best_coin = CoinStub.get_by_idx(best_pair[1])
+            bridge_balance = self.manager.get_currency_balance(self.config.BRIDGE.symbol)
+            best_coin_buy_price, _ = prices[best_coin.symbol]
+            self.logger.info(f"Will be jumping from {coin.symbol} to {best_coin.symbol}")
+            result = self.transaction_through_bridge(coin, best_coin, coin_sell_price, best_coin_buy_price)
+            expected_sold_quantity = self.manager.sell_quantity(coin.symbol, self.config.BRIDGE.symbol, coin_amount)
+            expected_bridge = expected_sold_quantity * coin_sell_price * 0.999 + bridge_balance
+            expected_bought_quantity_no_fees = self.manager.buy_quantity(
+                best_coin.symbol, self.config.BRIDGE.symbol, expected_bridge, best_coin_buy_price
+            )
+            self.logger.info(
+                f"Expected: {expected_bought_quantity_no_fees:0.08f}, "
+                f"Actual: {result.cumulative_filled_quantity:0.08f}, "
+                f"Slippage: {expected_bought_quantity_no_fees/result.cumulative_filled_quantity - 1:0.06%}"
+            )
 
     @postpone_heavy_calls
     def bridge_scout(self):

--- a/binance_trade_bot/config.py
+++ b/binance_trade_bot/config.py
@@ -46,6 +46,9 @@ class Config:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
         )
 
         self.USE_MARGIN = os.environ.get("USE_MARGIN") or config.get(USER_CFG_SECTION, "use_margin")
+        self.USE_MARGIN = {"yes": True, "no": False}.get(self.USE_MARGIN)
+        if self.USE_MARGIN is None:
+            raise ValueError("use_margin parameter must be either 'yes' or 'no'")
         self.SCOUT_MARGIN = os.environ.get("SCOUT_MARGIN") or config.get(USER_CFG_SECTION, "scout_margin")
         self.SCOUT_MARGIN = float(self.SCOUT_MARGIN)
 

--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -18,7 +18,7 @@ from .config import Config
 from .logger import Logger
 from .models import *  # pylint: disable=wildcard-import
 
-LogScout = namedtuple("LogScout", ["pair_id", "target_ratio", "coin_price", "optional_coin_price"])
+LogScout = namedtuple("LogScout", ["pair_id", "ratio_diff", "target_ratio", "coin_price", "optional_coin_price"])
 
 
 class Database:
@@ -155,6 +155,7 @@ class Database:
                 [
                     {
                         "pair_id": ls.pair_id,
+                        "ratio_diff": ls.ratio_diff,
                         "target_ratio": ls.target_ratio,
                         "current_coin_price": ls.coin_price,
                         "other_coin_price": ls.optional_coin_price,
@@ -238,6 +239,11 @@ class Database:
 
     def create_database(self):
         Base.metadata.create_all(self.engine)
+        try:
+            with self.db_session() as session:
+                session.execute("ALTER TABLE scout_history ADD COLUMN ratio_diff float;")
+        except:
+            pass
 
     def start_trade_log(self, from_coin: str, to_coin: str, selling: bool):
         return TradeLog(self, from_coin, to_coin, selling)

--- a/binance_trade_bot/models/scout_history.py
+++ b/binance_trade_bot/models/scout_history.py
@@ -16,6 +16,7 @@ class ScoutHistory(Base):
     pair_id = Column(String, ForeignKey("pairs.id"))
     pair = relationship("Pair")
 
+    ratio_diff = Column(Float)
     target_ratio = Column(Float)
     current_coin_price = Column(Float)
     other_coin_price = Column(Float)
@@ -25,11 +26,13 @@ class ScoutHistory(Base):
     def __init__(
         self,
         pair: Pair,
+        ratio_diff: float,
         target_ratio: float,
         current_coin_price: float,
         other_coin_price: float,
     ):
         self.pair = pair
+        self.ratio_diff = ratio_diff
         self.target_ratio = target_ratio
         self.current_coin_price = current_coin_price
         self.other_coin_price = other_coin_price
@@ -43,6 +46,7 @@ class ScoutHistory(Base):
         return {
             "from_coin": self.pair.from_coin.info(),
             "to_coin": self.pair.to_coin.info(),
+            "ratio_diff": self.ratio_diff,
             "current_ratio": self.current_ratio,
             "target_ratio": self.target_ratio,
             "current_coin_price": self.current_coin_price,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sqlitedict==1.7.0
 unicorn-binance-websocket-api==1.31.0
 unicorn-fy==0.11.0
 sortedcontainers
+tabulate

--- a/show_ratio_changes.py
+++ b/show_ratio_changes.py
@@ -1,0 +1,70 @@
+"""
+This script will display a table of the latest values in ratio_dict,
+i.e. the current ratio changes.
+"""
+
+import os
+from tabulate import tabulate
+import sqlite3
+from configparser import ConfigParser
+from datetime import datetime
+
+
+abspath = os.path.abspath(__file__)
+dname = os.path.dirname(abspath)
+os.chdir(dname)
+
+db_file_path = "data/crypto_trading.db"
+assert os.path.exists(db_file_path), f"⚠ Unable to find database file at '{db_file_path}'"
+
+user_cfg_file_path = "user.cfg"
+assert os.path.exists(user_cfg_file_path), f"⚠ Unable to find user config file at '{user_cfg_file_path}'"
+with open(user_cfg_file_path) as cfg:
+    config = ConfigParser()
+    config.read_file(cfg)
+    use_margin = config.get("binance_user_config", "use_margin")
+
+con = sqlite3.connect(db_file_path)
+con.row_factory = sqlite3.Row
+cur = con.cursor()
+cur.execute("""
+    SELECT pairs.from_coin_id, pairs.to_coin_id, scout_history.ratio_diff FROM scout_history
+    LEFT JOIN pairs ON scout_history.pair_id = pairs.id WHERE datetime = (SELECT max(datetime) from scout_history)
+    ORDER BY scout_history.ratio_diff ASC;
+""")
+
+ratio_dict = cur.fetchall()
+
+last_time = cur.execute("SELECT max(datetime) as datetime FROM scout_history LIMIT 1;").fetchone()
+last_time = datetime.strptime(last_time["datetime"], "%Y-%m-%d %H:%M:%S.%f").strftime("%Y-%m-%d %H:%M:%S")
+
+current_coin = ratio_dict[0]["from_coin_id"]
+
+ratio_dict_out = []
+for x in ratio_dict:
+    l = [x["to_coin_id"], x["ratio_diff"]]
+    if use_margin:
+        # This is percentage where 100% = (100% + SCOUT_MARGIN)
+        # percent = (x.ratio + 1) * (1 + config.SCOUT_MARGIN / 100) * 100
+        percent = (x["ratio_diff"] + 1) * 100
+        l.append(f"{percent:.2f}%")
+    ratio_dict_out.append(l)
+
+header = ["To coin", "Ratio"]
+
+print(f"Current coin: {current_coin}")
+print(f"Last update time: {last_time}")
+
+if use_margin:
+    scout_margin = float(config.get("binance_user_config", "scout_margin"))
+    header.append("% accumulation")
+    print(f"Scout margin: {scout_margin}% (jump on perc. accum. ~ {100 + scout_margin / 100}%)")
+
+print(tabulate(
+    ratio_dict_out,
+    headers=header,
+    tablefmt="fancy_grid",
+    numalign="left",
+    stralign="left",
+    floatfmt=".2f"
+))


### PR DESCRIPTION
1. Treat `use_margin` parameter as boolean.
2. Dispatch `_jump_to_best_coin()` method based on the `use_margin` parameter
    - If `use_margin=no`, then the original squashed-jumps-preventing method from idkravitz's fork will be used.
    - If `use_margin=yes`, then method almost identical to edeng23's one will be used.
3. Save `ratio_dict` values to `scout_history` table, script for displaying the latest `ratio_dict` values, updated `README.md`.
   - Example output from `show_ratio_changes.py`:

```
$ python3 show_ratio_changes.py
Current coin: ATOM
Last update time: 2021-12-06 21:26:28
Scout margin: 0.8% (jump on perc. accum. ~ 100.008%)
╒═══════════╤═════════╤══════════════════╕
│ To coin   │ Ratio   │ % accumulation   │
╞═══════════╪═════════╪══════════════════╡
│ IOTA      │ -0.02   │ 97.60%           │
├───────────┼─────────┼──────────────────┤
│ VET       │ -0.02   │ 98.19%           │
├───────────┼─────────┼──────────────────┤
│ ADA       │ -0.02   │ 98.25%           │
├───────────┼─────────┼──────────────────┤
│ ONT       │ -0.01   │ 98.51%           │
├───────────┼─────────┼──────────────────┤
│ QTUM      │ -0.01   │ 98.57%           │
├───────────┼─────────┼──────────────────┤
│ ICX       │ -0.01   │ 98.62%           │
├───────────┼─────────┼──────────────────┤
│ OMG       │ -0.01   │ 98.72%           │
├───────────┼─────────┼──────────────────┤
│ DOGE      │ -0.01   │ 98.75%           │
├───────────┼─────────┼──────────────────┤
│ NEO       │ -0.01   │ 98.75%           │
├───────────┼─────────┼──────────────────┤
│ DASH      │ -0.01   │ 98.80%           │
├───────────┼─────────┼──────────────────┤
│ ETC       │ -0.01   │ 98.81%           │
├───────────┼─────────┼──────────────────┤
│ BAT       │ -0.01   │ 98.87%           │
├───────────┼─────────┼──────────────────┤
│ XLM       │ -0.01   │ 98.92%           │
├───────────┼─────────┼──────────────────┤
│ EOS       │ -0.01   │ 98.93%           │
├───────────┼─────────┼──────────────────┤
│ BTT       │ -0.01   │ 98.96%           │
├───────────┼─────────┼──────────────────┤
│ TRX       │ -0.01   │ 99.17%           │
├───────────┼─────────┼──────────────────┤
│ XMR       │ -0.01   │ 99.18%           │
╘═══════════╧═════════╧══════════════════╛
```