### PR TITLE
python Import Error: cannot import name 'BaseResponse' from 'werkzeug.wrappers' and cannot import name 'escape' from 'jinja2'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ unicorn-fy==0.11.0
 sortedcontainers
 tabulate
 itsdangerous==2.0.1
+jinja2==3.0.3
+werkzeug==2.0.3


### PR DESCRIPTION
From Installing from Fresh, I encountered these 2 errors. Looks like I needed to downgrade those versions to this:

jinja2==3.0.3
werkzeug==2.0.3