### PR TITLE
Avoid importing eventlet via socketio

### DIFF
--- a/binance_trade_bot/database.py
+++ b/binance_trade_bot/database.py
@@ -6,8 +6,6 @@ from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta
 from typing import List, Optional, Union
 
-from socketio import Client
-from socketio.exceptions import ConnectionError as SocketIOConnectionError
 from sqlalchemy import bindparam, create_engine, func, insert, select, update
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
@@ -28,9 +26,13 @@ class Database:
         self.engine = create_engine(uri)
         self.session_factory = scoped_session(sessionmaker(bind=self.engine))
         self.ratios_manager: Optional[RatiosManager] = None
-        self.socketio_client = Client()
+        self.socketio_client = None
 
     def socketio_connect(self):
+        from socketio.exceptions import ConnectionError as SocketIOConnectionError
+        if self.socketio_client is None:
+            from socketio import Client
+            self.socketio_client = Client()
         if self.socketio_client.connected and self.socketio_client.namespaces:
             return True
         try:


### PR DESCRIPTION
## Summary
- Prevent socketio from pulling in eventlet at import time by lazily creating the socketio client
- Initialize socketio client only when needed in `Database.socketio_connect`

## Testing
- `pytest` *(fails: HTTPSConnectionPool(host='api.binance.com', port=443): Max retries exceeded with url: /api/v3/ping (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68a61f25439883288284a850662e1976